### PR TITLE
Replace `activesupport` dependency with `dry-inflector`

### DIFF
--- a/lib/rodf/container.rb
+++ b/lib/rodf/container.rb
@@ -2,14 +2,16 @@
 #
 # This file is part of rODF.
 
-require 'active_support/inflector'
+require 'dry/inflector'
 
 module RODF
   class Container
+    INFLECTOR = Dry::Inflector.new.freeze
+
     def self.contains(*stuffs_array)
       stuffs_array.map {|sym| sym.to_s}.each do |stuffs|
-        stuff = stuffs.to_s.singularize
-        stuff_class = RODF.const_get(stuff.camelize)
+        stuff = INFLECTOR.singularize(stuffs.to_s)
+        stuff_class = RODF.const_get(INFLECTOR.camelize(stuff))
 
         define_method stuffs do
           instance_variable_name = :"@#{stuffs}"

--- a/rodf.gemspec
+++ b/rodf.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency 'builder', '>= 3.0'
+  s.add_runtime_dependency 'dry-inflector', '~> 0.1'
   s.add_runtime_dependency 'rubyzip', '>= 1.0'
-  s.add_runtime_dependency 'activesupport', '>= 3.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
`activesupport` 4 or newer requires old `tzinfo` verion,
and it's impossible to use actual versions of `activesupport`
with unreleased version of `tzinfo` in one project.

Also, `activesupport` versions less then `4` has security vulnerability:                                                                                       
https://groups.google.com/forum/#!topic/rubyonrails-security/bahr2JLnxvk