### PR TITLE
Remove GNU General Public License from files (as comment)

### DIFF
--- a/lib/rodf/cell.rb
+++ b/lib/rodf/cell.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'date'
 

--- a/lib/rodf/column.rb
+++ b/lib/rodf/column.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/compatibility.rb
+++ b/lib/rodf/compatibility.rb
@@ -1,19 +1,7 @@
 # Copyright (c) 2010-2012 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
 
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 require 'builder'
 
 if !String.method_defined? :to_xs

--- a/lib/rodf/container.rb
+++ b/lib/rodf/container.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'active_support/inflector'
 

--- a/lib/rodf/data_style.rb
+++ b/lib/rodf/data_style.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/document.rb
+++ b/lib/rodf/document.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'zip'
 

--- a/lib/rodf/hyperlink.rb
+++ b/lib/rodf/hyperlink.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/master_page.rb
+++ b/lib/rodf/master_page.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/page_layout.rb
+++ b/lib/rodf/page_layout.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/paragraph.rb
+++ b/lib/rodf/paragraph.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/paragraph_container.rb
+++ b/lib/rodf/paragraph_container.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/property.rb
+++ b/lib/rodf/property.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/row.rb
+++ b/lib/rodf/row.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/skeleton.rb
+++ b/lib/rodf/skeleton.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'erb'
 

--- a/lib/rodf/span.rb
+++ b/lib/rodf/span.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/spreadsheet.rb
+++ b/lib/rodf/spreadsheet.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'rodf/data_style'
 require 'rodf/document'

--- a/lib/rodf/style.rb
+++ b/lib/rodf/style.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/style_section.rb
+++ b/lib/rodf/style_section.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/tab.rb
+++ b/lib/rodf/tab.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/table.rb
+++ b/lib/rodf/table.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/lib/rodf/text.rb
+++ b/lib/rodf/text.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require 'builder'
 

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/data_style_spec.rb
+++ b/spec/data_style_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/file_storage_spec.rb
+++ b/spec/file_storage_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/hyperlink_spec.rb
+++ b/spec/hyperlink_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/master_page_spec.rb
+++ b/spec/master_page_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/page_layout_spec.rb
+++ b/spec/page_layout_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/paragraph_spec.rb
+++ b/spec/paragraph_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/row_spec.rb
+++ b/spec/row_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/skeleton_spec.rb
+++ b/spec/skeleton_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2012 Foivos Zakkak
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/span_spec.rb
+++ b/spec/span_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/spreadsheet_spec.rb
+++ b/spec/spreadsheet_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/style_section_spec.rb
+++ b/spec/style_section_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/style_spec.rb
+++ b/spec/style_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/tab_spec.rb
+++ b/spec/tab_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2008 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -1,19 +1,6 @@
 # Copyright (c) 2010 Thiago Arrais
 #
 # This file is part of rODF.
-#
-# rODF is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of
-# the License, or (at your option) any later version.
-
-# rODF is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-
-# You should have received a copy of the GNU Lesser General Public License
-# along with rODF.  If not, see <http://www.gnu.org/licenses/>.
 
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 


### PR DESCRIPTION
License was replaced with MIT in f38bca8.