### PR TITLE
Don't change block scope if parameter is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ RODF::Spreadsheet.file("my-spreadsheet.ods") do
 end
 ```
 
+For access to variables and methods from outer code you can use block parameter:
+
+```ruby
+require 'rodf'
+
+@data = 'Hello, rODF world!'
+
+RODF::Spreadsheet.file("my-spreadsheet.ods") do |spreadsheet|
+  spreadsheet.table 'My first table from Ruby' do |table|
+    table.row do |row|
+      row.cell @data
+    end
+  end
+end
+```
+
 Styling and formatting is also possible:
 
 ```ruby

--- a/lib/rodf/cell.rb
+++ b/lib/rodf/cell.rb
@@ -16,6 +16,8 @@ module RODF
     alias :p :paragraph
 
     def initialize(value=nil, opts={})
+      super
+
       if value.is_a?(Hash)
         opts = value
         value = ''

--- a/lib/rodf/container.rb
+++ b/lib/rodf/container.rb
@@ -24,8 +24,7 @@ module RODF
         end
 
         define_method stuff do |*args, &contents|
-          c = stuff_class.new(*args)
-          c.instance_exec(c, &contents) if contents
+          c = stuff_class.new(*args, &contents)
           public_send(stuffs) << c
           c
         end
@@ -37,9 +36,18 @@ module RODF
     end
 
     def self.create(*args, &contents)
-      container = new(*args)
-      container.instance_exec(container, &contents) if contents
+      container = new(*args, &contents)
       container.xml
+    end
+
+    def initialize(*_args, &contents)
+      return unless contents
+
+      if contents.arity.zero?
+        instance_exec(self, &contents)
+      else
+        yield(self)
+      end
     end
   end
 end

--- a/lib/rodf/data_style.rb
+++ b/lib/rodf/data_style.rb
@@ -14,6 +14,8 @@ module RODF
     alias section style_section
 
     def initialize(name, type)
+      super
+
       @type, @name = type, name
     end
 

--- a/lib/rodf/document.rb
+++ b/lib/rodf/document.rb
@@ -13,7 +13,12 @@ module RODF
     contains :styles, :default_styles, :office_styles
 
     def self.file(ods_file_name, &contents)
-      (doc = new).instance_exec(doc, &contents)
+      doc = new
+      if contents.arity.zero?
+        contents.call(doc)
+      else
+        doc.instance_exec(doc, &contents)
+      end
       doc.write_to ods_file_name
     end
 

--- a/lib/rodf/hyperlink.rb
+++ b/lib/rodf/hyperlink.rb
@@ -9,6 +9,8 @@ require_relative 'paragraph_container'
 module RODF
   class Hyperlink < ParagraphContainer
     def initialize(first, second = {})
+      super
+
       if second.instance_of?(Hash) && second.empty?
         @href = first
       else

--- a/lib/rodf/page_layout.rb
+++ b/lib/rodf/page_layout.rb
@@ -12,6 +12,8 @@ module RODF
     contains :properties
 
     def initialize(name)
+      super
+
       @name = name
     end
 

--- a/lib/rodf/paragraph.rb
+++ b/lib/rodf/paragraph.rb
@@ -9,6 +9,8 @@ require_relative 'paragraph_container'
 module RODF
   class Paragraph < ParagraphContainer
     def initialize(fst = nil, snd = {})
+      super
+
       first_is_hash = fst.instance_of? Hash
       span(fst) unless first_is_hash
       @elem_attrs = make_element_attributes(first_is_hash ? fst : snd)

--- a/lib/rodf/row.rb
+++ b/lib/rodf/row.rb
@@ -16,6 +16,8 @@ module RODF
     def initialize(number=0, opts={})
       @number = number
       @style = opts[:style]
+
+      super
     end
 
     def xml

--- a/lib/rodf/span.rb
+++ b/lib/rodf/span.rb
@@ -20,6 +20,8 @@ module RODF
 
   class Span < ParagraphContainer
     def initialize(first, second = nil)
+      super
+
       @style = nil
 
       if first.instance_of?(Symbol)

--- a/lib/rodf/style.rb
+++ b/lib/rodf/style.rb
@@ -14,6 +14,8 @@ module RODF
     FAMILIES = {cell: 'table-cell', column: 'table-column', row: 'table-row'}
 
     def initialize(name='', opts={}, node_tag='style:style')
+      super
+
       @name, @node_tag = name, node_tag
       @elem_attrs = make_element_attributes(@name, opts)
     end

--- a/lib/rodf/table.rb
+++ b/lib/rodf/table.rb
@@ -15,12 +15,20 @@ module RODF
     def initialize(title = nil)
       @title = title
       @last_row = 0
+
+      super
     end
 
     alias create_row row
     def row(options = {}, &contents)
-      create_row(next_row, options) do
-        instance_exec(self, &contents) if contents
+      create_row(next_row, options) do |row|
+        if contents
+          if contents.arity.zero?
+            row.instance_exec(row, &contents)
+          else
+            yield(row)
+          end
+        end
       end
     end
 

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -44,12 +44,24 @@ describe RODF::Table do
   end
 
   it "should accept parameterless block" do
+    inner = nil
     output = RODF::Table.create('MyTable') {
       row
       row
+
+      inner = self
     }
+    expect(inner).to be_an_instance_of RODF::Table
     output.should have_tag('//table:table/*', count: 2)
     output.should have_tag('//table:table-row')
+  end
+
+  it "should not instance exec inside block with parameter" do
+    inner = nil
+    RODF::Table.create('MyTable') do |t|
+      inner = self
+    end
+    expect(inner).to be self
   end
 
   it "should have children that accept parameterless blocks too" do


### PR DESCRIPTION
If there is a block parameter — just call the block.

It allows to use data (variables, methods) from external (outer) code.