### PR TITLE
Add `Row#add_cells` and `Table#add_rows` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ RODF::Spreadsheet.file("my-spreadsheet.ods") do |spreadsheet|
 end
 ```
 
+Bunches are also possible:
+
+```ruby
+require 'rodf'
+
+RODF::Spreadsheet.file("my-spreadsheet.ods") do
+  table 'My first table from Ruby' do
+    row do
+      add_cells ['ID', 'Name']
+    end
+
+    add_rows([
+      [1, 'Alice'],
+      [2, { value: 'Bob', color: '#ff0000'}],
+      [3, 'Carol']
+    ])
+  end
+end
+```
+
 Styling and formatting is also possible:
 
 ```ruby

--- a/lib/rodf/cell.rb
+++ b/lib/rodf/cell.rb
@@ -20,7 +20,7 @@ module RODF
 
       if value.is_a?(Hash)
         opts = value
-        value = ''
+        value = opts[:value]
       else
         if value.is_a?(String)
           value = value.strip

--- a/lib/rodf/container.rb
+++ b/lib/rodf/container.rb
@@ -13,26 +13,45 @@ module RODF
         stuff = INFLECTOR.singularize(stuffs.to_s)
         stuff_class = RODF.const_get(INFLECTOR.camelize(stuff))
 
-        define_method stuffs do
-          instance_variable_name = :"@#{stuffs}"
+        module_for_stuff.instance_exec do
+          define_method stuffs do
+            instance_variable_name = :"@#{stuffs}"
 
-          if instance_variable_defined?(instance_variable_name)
-            return instance_variable_get(instance_variable_name)
+            if instance_variable_defined?(instance_variable_name)
+              return instance_variable_get(instance_variable_name)
+            end
+
+            instance_variable_set(instance_variable_name, [])
           end
 
-          instance_variable_set(instance_variable_name, [])
-        end
+          define_method stuff do |*args, &contents|
+            c = stuff_class.new(*args, &contents)
+            public_send(stuffs) << c
+            c
+          end
 
-        define_method stuff do |*args, &contents|
-          c = stuff_class.new(*args, &contents)
-          public_send(stuffs) << c
-          c
-        end
+          define_method "add_#{stuffs}" do |*elements|
+            elements = elements.first if elements.first.is_a?(Array)
+            elements.each do |element|
+              public_send(stuff, element)
+            end
+          end
 
-        define_method "#{stuffs}_xml" do
-          public_send(stuffs).map(&:xml).join
+          define_method "#{stuffs}_xml" do
+            public_send(stuffs).map(&:xml).join
+          end
         end
       end
+    end
+
+    def self.module_for_stuff
+      if const_defined?(:StuffMethods, false)
+        mod = const_get(:StuffMethods)
+      else
+        mod = const_set(:StuffMethods, Module.new)
+        include mod
+      end
+      mod
     end
 
     def self.create(*args, &contents)

--- a/lib/rodf/table.rb
+++ b/lib/rodf/table.rb
@@ -32,6 +32,14 @@ module RODF
       end
     end
 
+    def add_rows(*rows)
+      rows = rows.first if rows.first.first.is_a?(Array)
+      rows.each do |row|
+        created = self.row
+        created.add_cells row
+      end
+    end
+
     def xml
       Builder::XmlMarkup.new.table:table, 'table:name' => @title do |xml|
         xml << columns_xml

--- a/spec/row_spec.rb
+++ b/spec/row_spec.rb
@@ -29,6 +29,27 @@ describe RODF::Row do
     output.should have_tag('//table:table-cell')
   end
 
+  it "should has `add_cells` method" do
+    output = RODF::Row.create do
+      add_cells({ value: 1, type: :string }, 2, 3)
+      add_cells [{ value: 4, type: :string }, 5, 6]
+    end
+
+    cells = Hpricot(output).search('table:table-cell')
+
+    cells[0]['office:value-type'].should eq 'string'
+    cells[0].at('text:p').innerHTML.should eq '1'
+
+    cells[1]['office:value-type'].should eq 'float'
+    cells[1]['office:value'].should eq '2'
+
+    cells[3]['office:value-type'].should eq 'string'
+    cells[3].at('text:p').innerHTML.should eq '4'
+
+    cells[4]['office:value-type'].should eq 'float'
+    cells[4]['office:value'].should eq '5'
+  end
+
   it "should be stylable in the initialization" do
     output = RODF::Row.create 0, style: 'dark' do
       cell

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -56,6 +56,57 @@ describe RODF::Table do
     output.should have_tag('//table:table-row')
   end
 
+  it "should has `add_rows` method" do
+    output = RODF::Table.create('MyTable') {
+      add_rows [{ value: 1, type: :string }, 2, 3], [4, 5, 6]
+      add_rows [[{ value: 7, type: :string }, 8, 9], [10, 11, 12]]
+      add_rows [[13, { value: 14, type: :string }, 15], [16, 17, 18]]
+    }
+    output.should have_tag('//table:table/*', count: 6)
+    output.should have_tag('//table:table-row')
+
+    rows = Hpricot(output).search('table:table-row')
+
+    cells0 = rows[0].search('table:table-cell')
+
+    cells0[0]['office:value-type'].should eq 'string'
+    cells0[0].at('text:p').innerHTML.should eq '1'
+
+    cells0[1]['office:value-type'].should eq 'float'
+    cells0[1]['office:value'].should eq '2'
+
+    cells1 = rows[1].search('table:table-cell')
+
+    cells1[0]['office:value-type'].should eq 'float'
+    cells1[0]['office:value'].should eq '4'
+
+    cells2 = rows[2].search('table:table-cell')
+
+    cells2[0]['office:value-type'].should eq 'string'
+    cells2[0].at('text:p').innerHTML.should eq '7'
+
+    cells2[1]['office:value-type'].should eq 'float'
+    cells2[1]['office:value'].should eq '8'
+
+    cells3 = rows[3].search('table:table-cell')
+
+    cells3[0]['office:value-type'].should eq 'float'
+    cells3[0]['office:value'].should eq '10'
+
+    cells4 = rows[4].search('table:table-cell')
+
+    cells4[0]['office:value-type'].should eq 'float'
+    cells4[0]['office:value'].should eq '13'
+
+    cells4[1]['office:value-type'].should eq 'string'
+    cells4[1].at('text:p').innerHTML.should eq '14'
+
+    cells5 = rows[5].search('table:table-cell')
+
+    cells5[0]['office:value-type'].should eq 'float'
+    cells5[0]['office:value'].should eq '16'
+  end
+
   it "should not instance exec inside block with parameter" do
     inner = nil
     RODF::Table.create('MyTable') do |t|


### PR DESCRIPTION
It allows to add bunches of data in Ruby-core types,
internally converting them to rows and cells.