### PR TITLE
Remove `target='_blank'` for links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # RODF
-<a href="https://badge.fury.io/rb/rodf" target="_blank"><img height="21" style='border:0px;height:21px;' border='0' src="https://badge.fury.io/rb/rodf.svg" alt="Gem Version"></a>
-<a href='https://travis-ci.org/westonganger/rodf' target='_blank'><img height='21' style='border:0px;height:21px;' src='https://api.travis-ci.org/westonganger/rodf.svg?branch=master' border='0' alt='Build Status' /></a>
-<a href='https://rubygems.org/gems/rodf' target='_blank'><img height='21' style='border:0px;height:21px;' src='https://ruby-gem-downloads-badge.herokuapp.com/rodf?label=rubygems&type=total&total_label=downloads&color=brightgreen' border='0' alt='RubyGems Downloads' /></a>
-<a href='https://ko-fi.com/A5071NK' target='_blank'><img height='22' style='border:0px;height:22px;' src='https://az743702.vo.msecnd.net/cdn/kofi1.png?v=a' border='0' alt='Buy Me a Coffee' /></a>
+
+<a href="https://badge.fury.io/rb/rodf"><img height="21" style='border:0px;height:21px;' border='0' src="https://badge.fury.io/rb/rodf.svg" alt="Gem Version"></a>
+<a href='https://travis-ci.org/westonganger/rodf'><img height='21' style='border:0px;height:21px;' src='https://api.travis-ci.org/westonganger/rodf.svg?branch=master' border='0' alt='Build Status' /></a>
+<a href='https://rubygems.org/gems/rodf'><img height='21' style='border:0px;height:21px;' src='https://ruby-gem-downloads-badge.herokuapp.com/rodf?label=rubygems&type=total&total_label=downloads&color=brightgreen' border='0' alt='RubyGems Downloads' /></a>
+<a href='https://ko-fi.com/A5071NK'><img height='22' style='border:0px;height:22px;' src='https://az743702.vo.msecnd.net/cdn/kofi1.png?v=a' border='0' alt='Buy Me a Coffee' /></a>
 
 This is a library for writing to ODF output from Ruby. It mainly focuses creating ODS spreadsheets.
 


### PR DESCRIPTION
GitHub cuts this attribute:

![image](https://user-images.githubusercontent.com/6510020/50513246-8e04b480-0aa7-11e9-9ca8-ac36e1bd3275.png)

And `_` can break Markdown syntax highlighting:

### Atom Editor

Before:

![image](https://user-images.githubusercontent.com/6510020/50513167-1898e400-0aa7-11e9-8dae-8f99cf6dc0f3.png)

After:

![image](https://user-images.githubusercontent.com/6510020/50513176-28182d00-0aa7-11e9-80a9-64e61cdaca45.png)

### GitHub Web (blame)

Before:

![image](https://user-images.githubusercontent.com/6510020/50513207-57c73500-0aa7-11e9-9ffd-e5db4bdd6b9f.png)

After:

![image](https://user-images.githubusercontent.com/6510020/50513214-67467e00-0aa7-11e9-959a-2ceea4e3f40c.png)
