### PR TITLE
Add license to gemspec for easier automatic discovery

### DIFF
--- a/rodf.gemspec
+++ b/rodf.gemspec
@@ -10,7 +10,8 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/thiagoarrais/rodf'
   s.authors = ['Weston Ganger', 'Thiago Arrais']
   s.email = ["weston@westonganger.com", "thiago.arrais@gmail.com"]
-
+  s.license = "MIT"
+  
   s.files = Dir.glob("{lib/**/*}") + %w{ LICENSE README.md Rakefile CHANGELOG.md }
   s.require_path = 'lib'
 


### PR DESCRIPTION
The LICENSE file already defines this gem as MIT, but this adds that info to the gemspec as well